### PR TITLE
Add a `project.scripts` section to `pyproject.toml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
 __pycache__/
+env/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ description = "Autoadd default values to stubs"
 requires-python = ">=3.7"
 dependencies = ["libcst", "typeshed_client", "tomli"]
 
+[project.scripts]
+stubdefaulter = "stubdefaulter:main"
+
 [project.optional-dependencies]
 dev = [
     "black==22.12.0",            # Must match .pre-commit-config.yaml
@@ -17,4 +20,5 @@ dev = [
     "isort==5.11.4",             # Must match .pre-commit-config.yaml
     "mypy==0.991",
     "pre-commit-hooks==4.4.0",   # Must match .pre-commit-config.yaml
+    "pytest",
 ]


### PR DESCRIPTION
This means you can invoke the tool by doing `stubdefaulter [args]` instead of `python -m stubdefaulter [args]`. Also: add `pytest` to the dev-dependencies so it's installed if you do `pip install -e .[dev]` locally.