### PR TITLE
Skip a few annoying modules when adding defaults to the stdlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ virtual environment.
 - Example invocations:
   - `python -m stubdefaulter --stdlib-path path/to/typeshed/stdlib`
     - Add defaults to the stdlib stubs in typeshed
-    - Fun things will happen when it tries to add defaults to `antigravity`
   - `python -m stubdefaulter --packages path/to/typeshed/stubs/requests path/to/typeshed/stubs/babel`
     - Add defaults to the `requests` and `babel` packages in typeshed
     - Assumes you already have these installed locally

--- a/stubdefaulter.py
+++ b/stubdefaulter.py
@@ -8,8 +8,10 @@ Tool to add default values to stubs.
 
 import argparse
 import ast
+import contextlib
 import importlib
 import inspect
+import io
 import subprocess
 import sys
 import textwrap
@@ -160,7 +162,9 @@ def add_defaults_to_stub(
     if path is None:
         raise ValueError(f"Could not find stub for {module_name}")
     try:
-        runtime_module = importlib.import_module(module_name)
+        # Redirect stdout when importing modules to avoid noisy output from modules like `this`
+        with contextlib.redirect_stdout(io.StringIO()):
+            runtime_module = importlib.import_module(module_name)
     # `importlib.import_module("multiprocessing.popen_fork")` crashes with AttributeError on Windows
     except Exception as e:
         print(f'Could not import {module_name}: {type(e).__name__}: "{e}"')
@@ -252,8 +256,7 @@ def install_typeshed_packages(typeshed_paths: Sequence[Path]) -> None:
 
 # `_typeshed` doesn't exist at runtime; no point trying to add defaults
 # `antigravity` exists at runtime but it's annoying to have the browser open up every time
-# `this` exists at runtime but results in noisy output being printed to the terminal when imported
-STDLIB_MODULE_BLACKLIST = ("_typeshed/*.pyi", "antigravity.pyi", "this.pyi")
+STDLIB_MODULE_BLACKLIST = ("_typeshed/*.pyi", "antigravity.pyi")
 
 
 def main() -> None:

--- a/stubdefaulter.py
+++ b/stubdefaulter.py
@@ -297,14 +297,15 @@ def main() -> None:
     )
     errors = []
     for module, path in typeshed_client.get_all_stub_files(context):
-        if any(
-            path.relative_to(stdlib_path).match(pattern)
-            for pattern in STDLIB_MODULE_BLACKLIST
-        ):
-            print(f"Skipping {module}: blacklisted module")
-            continue
-        elif stdlib_path is not None and is_relative_to(path, stdlib_path):
-            errors += add_defaults_to_stub(module, context)
+        if stdlib_path is not None and is_relative_to(path, stdlib_path):
+            if any(
+                path.relative_to(stdlib_path).match(pattern)
+                for pattern in STDLIB_MODULE_BLACKLIST
+            ):
+                print(f"Skipping {module}: blacklisted module")
+                continue
+            else:
+                errors += add_defaults_to_stub(module, context)
         elif any(is_relative_to(path, p) for p in package_paths):
             errors += add_defaults_to_stub(module, context)
     sys.exit(1 if errors else 0)


### PR DESCRIPTION
- Skip trying to import `_typeshed` (obviously won't work)
- Skip trying to add defaults for `antigravity` (works, but it's annoying to have the browser open up every time)
- Suppress stdout when importing modules so that there isn't noisy output to the terminal when importing modules like `this`