### PR TITLE
Install pyanalyze when `pip install -e .[dev]` is run

### DIFF
--- a/.github/workflows/pyanalyze.yml
+++ b/.github/workflows/pyanalyze.yml
@@ -23,8 +23,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install
-        run: |
-          python -m pip install -e .
-          python -m pip install pyanalyze==0.9.0
+        run: python -m pip install -e .[pyanalyze]
       - name: Run
         run: PYTHONPATH=. python -m pyanalyze --config-file pyproject.toml stubdefaulter.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,9 @@ dependencies = ["libcst", "typeshed_client", "tomli"]
 stubdefaulter = "stubdefaulter:main"
 
 [project.optional-dependencies]
+pyanalyze = ["pyanalyze==0.9.0"]
 dev = [
+    "stubdefaulter[pyanalyze]",
     "black==22.12.0",            # Must match .pre-commit-config.yaml
     "flake8-bugbear==23.1.14",
     "flake8-noqa==1.3.0",


### PR DESCRIPTION
The self-dependency looks a bit weird, but it is apparently explicitly supported (can't find any better docs than this, though): https://discuss.python.org/t/pyproject-toml-optional-dependencies-redundancy-aka-dry-extras/8428/6. I found it somewhat annoying when pyanalyze failed on my PR #16, and I then realised I didn't have pyanalyze installed locally :)