### PR TITLE
Suppress some logs to the terminal from `typeshed_client`

### DIFF
--- a/stubdefaulter.py
+++ b/stubdefaulter.py
@@ -24,7 +24,6 @@ import libcst
 import tomli
 import typeshed_client
 
-
 # Suppress some somewhat noisy logging from typeshed_client
 logging.getLogger("typeshed_client").setLevel(logging.CRITICAL)
 

--- a/stubdefaulter.py
+++ b/stubdefaulter.py
@@ -169,7 +169,8 @@ def add_defaults_to_stub(
     except Exception as e:
         print(f'Could not import {module_name}: {type(e).__name__}: "{e}"')
         return []
-    stub_names = typeshed_client.get_stub_names(module_name, search_context=context)
+    with contextlib.redirect_stderr(io.StringIO()):
+        stub_names = typeshed_client.get_stub_names(module_name, search_context=context)
     if stub_names is None:
         raise ValueError(f"Could not find stub for {module_name}")
     stub_lines = path.read_text().splitlines()

--- a/stubdefaulter.py
+++ b/stubdefaulter.py
@@ -25,7 +25,7 @@ import tomli
 import typeshed_client
 
 
-# Suppress some somewhat noisy logging from the library
+# Suppress some somewhat noisy logging from typeshed_client
 logging.getLogger("typeshed_client").setLevel(logging.CRITICAL)
 
 

--- a/stubdefaulter.py
+++ b/stubdefaulter.py
@@ -12,6 +12,7 @@ import contextlib
 import importlib
 import inspect
 import io
+import logging
 import subprocess
 import sys
 import textwrap
@@ -21,6 +22,11 @@ from typing import Any, Dict, List, Sequence, Tuple
 
 import libcst
 import tomli
+
+# Do this before importing typeshed_client
+# to suppress some somewhat noisy logging from the library
+logging.getLogger("typeshed_client").setLevel(logging.CRITICAL)
+
 import typeshed_client
 
 
@@ -169,8 +175,7 @@ def add_defaults_to_stub(
     except Exception as e:
         print(f'Could not import {module_name}: {type(e).__name__}: "{e}"')
         return []
-    with contextlib.redirect_stderr(io.StringIO()):
-        stub_names = typeshed_client.get_stub_names(module_name, search_context=context)
+    stub_names = typeshed_client.get_stub_names(module_name, search_context=context)
     if stub_names is None:
         raise ValueError(f"Could not find stub for {module_name}")
     stub_lines = path.read_text().splitlines()

--- a/stubdefaulter.py
+++ b/stubdefaulter.py
@@ -22,12 +22,11 @@ from typing import Any, Dict, List, Sequence, Tuple
 
 import libcst
 import tomli
-
-# Do this before importing typeshed_client
-# to suppress some somewhat noisy logging from the library
-logging.getLogger("typeshed_client").setLevel(logging.CRITICAL)
-
 import typeshed_client
+
+
+# Suppress some somewhat noisy logging from the library
+logging.getLogger("typeshed_client").setLevel(logging.CRITICAL)
 
 
 def infer_value_of_node(node: libcst.BaseExpression) -> object:


### PR DESCRIPTION
Prior to this PR, here's what was printed to the terminal when processing the `tokenize` module:

```
Processing tokenize... Name is already imported in tokenize: NameInfo(name='__all__', is_exported=True, ast=ImportedName(module_name=('token',), name='__all__'), child_nodes=None)
Name is already imported in tokenize: NameInfo(name='__all__', is_exported=True, ast=ImportedName(module_name=('token',), name='__all__'), child_nodes=None)
Name is already imported in tokenize: NameInfo(name='__all__', is_exported=True, ast=ImportedName(module_name=('token',), name='__all__'), child_nodes=None)
Could not find _TokenInfo in runtime module
added 0 defaults
```

With this PR applied, this is changed to:

```
Processing tokenize... Could not find _TokenInfo in runtime module
added 0 defaults
```