### PR TITLE
Bump typeshed_client and flake8-bugbear pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "stubdefaulter"
 version = "0.0.0"
 description = "Autoadd default values to stubs"
 requires-python = ">=3.7"
-dependencies = ["libcst", "typeshed_client", "tomli"]
+dependencies = ["libcst", "typeshed_client>=2.2.0", "tomli"]
 
 [project.scripts]
 stubdefaulter = "stubdefaulter:main"
@@ -17,7 +17,7 @@ pyanalyze = ["pyanalyze==0.9.0"]
 dev = [
     "stubdefaulter[pyanalyze]",
     "black==22.12.0",            # Must match .pre-commit-config.yaml
-    "flake8-bugbear==23.1.14",
+    "flake8-bugbear==23.1.20",
     "flake8-noqa==1.3.0",
     "isort==5.11.4",             # Must match .pre-commit-config.yaml
     "mypy==0.991",


### PR DESCRIPTION
- Require the latest version of `typeshed_client`
- Bump `flake8-bugbear` to the latest version (matching what's run in CI, since it's unpinned in the pre-commit config). This ensures that you don't get a false-positive error when running flake8 locally (B028 was renamed to B907 in the latest release, but it's still called B028 in release `23.1.14`, meaning the ignore for B907 in the `.flake8` file doesn't work if you run flake8 locally).