### PR TITLE
Colorize output in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,6 +7,10 @@ on:
       - main
   pull_request:
 
+env:
+  FORCE_COLOR: 1
+  PY_COLORS: 1
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/typeshed_primer.yml
+++ b/.github/workflows/typeshed_primer.yml
@@ -9,6 +9,7 @@ permissions:
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
+  FORCE_COLOR: 1
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
In particular, having the `typeshed_primer` output colorized is useful for identifying at-a-glance why `stubdefaulter` is exiting with code 1 when run as part of the `typeshed_primer` workflow (it's a few troublesome defaults in typeshed's `locale.pyi`).

We may as well also add colors to `pytest` in CI while we're about it :)