### PR TITLE
Fall back to `getattr_static` on `AttributeError`

### DIFF
--- a/stubdefaulter.py
+++ b/stubdefaulter.py
@@ -192,7 +192,10 @@ def gather_funcs(
     if not isinstance(node.ast, interesting_classes):
         return
     try:
-        runtime = getattr(runtime_parent, name)
+        try:
+            runtime = getattr(runtime_parent, name)
+        except AttributeError:
+            runtime = inspect.getattr_static(runtime_parent, name)
     # Some getattr() calls raise TypeError, or something even more exotic
     except Exception:
         log("Could not find", fullname, "in runtime module")


### PR DESCRIPTION
This doesn't affect the total count of defaults which are added to the stdlib (at least not on my machine), but it does slightly reduce the number of 'Could not find <blah> in runtime module' messages that are logged to the terminal