### PR TITLE
Handle methods with mangled names

### DIFF
--- a/stubdefaulter.py
+++ b/stubdefaulter.py
@@ -210,9 +210,13 @@ def gather_funcs(
         if not node.child_nodes:
             return
         for child_name, child_node in node.child_nodes.items():
+            if child_name.startswith("__") and not child_name.endswith("__"):
+                maybe_mangled_child_name = f"_{name}{child_name}"
+            else:
+                maybe_mangled_child_name = child_name
             yield from gather_funcs(
                 node=child_node,
-                name=child_name,
+                name=maybe_mangled_child_name,
                 fullname=f"{fullname}.{child_name}",
                 runtime_parent=runtime,
                 blacklisted_objects=blacklisted_objects,

--- a/test_stubdefaulter.py
+++ b/test_stubdefaulter.py
@@ -28,6 +28,8 @@ class Capybara:
         pass
     def overloaded_method(x=False):
         return 1 if x else "1"
+    def __mangled(x="foo"):
+        pass
 
 class Klass:
     class NestedKlass1:
@@ -70,6 +72,7 @@ class Capybara:
     def overloaded_method(x: Literal[False] = ...) -> str: ...
     @overload
     def overloaded_method(x: Literal[True]) -> int: ...
+    def __mangled(x: str = ...) -> None: ...
 
 class Klass:
     class NestedKlass1:
@@ -108,6 +111,7 @@ class Capybara:
     def overloaded_method(x: Literal[False] = False) -> str: ...
     @overload
     def overloaded_method(x: Literal[True]) -> int: ...
+    def __mangled(x: str = 'foo') -> None: ...
 
 class Klass:
     class NestedKlass1:


### PR DESCRIPTION
Doesn't make a difference to the defaults added to the stdlib, but it reduces the number of 'Could not find method <blah> at runtime' messages printed to the terminal