### PR TITLE
Add some special casing for typing-module aliases

### DIFF
--- a/stubdefaulter.py
+++ b/stubdefaulter.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 import textwrap
 import types
+import typing
 from dataclasses import dataclass, field
 from itertools import chain
 from pathlib import Path
@@ -197,6 +198,9 @@ def gather_funcs(
     )
     if not isinstance(node.ast, interesting_classes):
         return
+    # special-case some aliases in the typing module
+    if isinstance(runtime_parent, type(typing.Mapping)):
+        runtime_parent = runtime_parent.__origin__  # type: ignore[attr-defined]
     try:
         try:
             runtime = getattr(runtime_parent, name)


### PR DESCRIPTION
This has the following effect on output printed to the terminal when running `stubdefaulter` on the stdlib:

```diff
--- a/old.txt
+++ b/new.txt
@@ -768,73 +768,23 @@ Could not find types.GenericAlias.__getattr__ at runtime
 added 0 defaults
 Processing typing... Could not find typing.type_check_only at runtime
 Could not find typing._Alias at runtime
-Could not find typing.Sized.__len__ at runtime
-Could not find typing.Iterable.__iter__ at runtime
-Could not find typing.Iterator.__next__ at runtime
-Could not find typing.Iterator.__iter__ at runtime
-Could not find typing.Reversible.__reversed__ at runtime
-Could not find typing.Generator.__next__ at runtime
-Could not find typing.Generator.__iter__ at runtime
 Could not find typing.Generator.gi_code at runtime
 Could not find typing.Generator.gi_frame at runtime
 Could not find typing.Generator.gi_running at runtime
 Could not find typing.Generator.gi_yieldfrom at runtime
-Could not find typing.Awaitable.__await__ at runtime
 Could not find typing.Coroutine.cr_await at runtime
 Could not find typing.Coroutine.cr_code at runtime
 Could not find typing.Coroutine.cr_frame at runtime
 Could not find typing.Coroutine.cr_running at runtime
 Could not find typing.AwaitableGenerator at runtime
-Could not find typing.AsyncIterable.__aiter__ at runtime
-Could not find typing.AsyncIterator.__anext__ at runtime
-Could not find typing.AsyncIterator.__aiter__ at runtime
-Could not find typing.AsyncGenerator.__anext__ at runtime
 Could not find typing.AsyncGenerator.ag_await at runtime
 Could not find typing.AsyncGenerator.ag_code at runtime
 Could not find typing.AsyncGenerator.ag_frame at runtime
 Could not find typing.AsyncGenerator.ag_running at runtime
-Could not find typing.Container.__contains__ at runtime
-Could not find typing.Collection.__len__ at runtime
 Skipping typing.Sequence.index: blacklisted object
-Could not find typing.Sequence.__contains__ at runtime
-Could not find typing.Sequence.__iter__ at runtime
-Could not find typing.Sequence.__reversed__ at runtime
-Could not find typing.MutableSequence.__setitem__ at runtime
-Could not find typing.MutableSequence.__delitem__ at runtime
-Could not find typing.MutableSequence.__iadd__ at runtime
-Could not find typing.AbstractSet.__contains__ at runtime
-Could not find typing.AbstractSet.__and__ at runtime
-Could not find typing.AbstractSet.__sub__ at runtime
-Could not find typing.AbstractSet.__xor__ at runtime
-Could not find typing.MutableSet.__ior__ at runtime
-Could not find typing.MutableSet.__iand__ at runtime
-Could not find typing.MutableSet.__ixor__ at runtime
-Could not find typing.MutableSet.__isub__ at runtime
-Could not find typing.MappingView.__len__ at runtime
-Could not find typing.ItemsView.__and__ at runtime
-Could not find typing.ItemsView.__rand__ at runtime
-Could not find typing.ItemsView.__contains__ at runtime
-Could not find typing.ItemsView.__iter__ at runtime
 Could not find typing.ItemsView.__reversed__ at runtime
-Could not find typing.ItemsView.__sub__ at runtime
-Could not find typing.ItemsView.__rsub__ at runtime
-Could not find typing.ItemsView.__xor__ at runtime
-Could not find typing.ItemsView.__rxor__ at runtime
-Could not find typing.KeysView.__and__ at runtime
-Could not find typing.KeysView.__rand__ at runtime
-Could not find typing.KeysView.__contains__ at runtime
-Could not find typing.KeysView.__iter__ at runtime
 Could not find typing.KeysView.__reversed__ at runtime
-Could not find typing.KeysView.__sub__ at runtime
-Could not find typing.KeysView.__rsub__ at runtime
-Could not find typing.KeysView.__xor__ at runtime
-Could not find typing.KeysView.__rxor__ at runtime
-Could not find typing.ValuesView.__contains__ at runtime
-Could not find typing.ValuesView.__iter__ at runtime
 Could not find typing.ValuesView.__reversed__ at runtime
-Could not find typing.Mapping.__contains__ at runtime
-Could not find typing.MutableMapping.__setitem__ at runtime
-Could not find typing.MutableMapping.__delitem__ at runtime
 Could not find typing.IO.__next__ at runtime
 Could not find typing.IO.__iter__ at runtime
 Could not find typing.NamedTuple._make at runtime
```