### PR TITLE
Add defaults to pos-only parameters in the stub, even if the parameter name is incorrect in the stub

### DIFF
--- a/stubdefaulter.py
+++ b/stubdefaulter.py
@@ -74,7 +74,11 @@ class ReplaceEllipsesUsingRuntime(libcst.CSTTransformer):
         except KeyError:
             pass
 
-        if param_name.startswith("__") and not param_name.endswith("__"):
+        if (
+            node in self.stub_params.params
+            and param_name.startswith("__")
+            and not param_name.endswith("__")
+        ):
             try:
                 return self.sig.parameters[param_name[2:]]
             except KeyError:
@@ -94,7 +98,11 @@ class ReplaceEllipsesUsingRuntime(libcst.CSTTransformer):
             return None
 
         all_stub_params = list(
-            chain(self.stub_params.params, self.stub_params.kwonly_params)
+            chain(
+                self.stub_params.posonly_params,
+                self.stub_params.params,
+                self.stub_params.kwonly_params,
+            )
         )
         num_stub_params = len(all_stub_params)
         num_runtime_params = len(all_runtime_parameters)

--- a/stubdefaulter.py
+++ b/stubdefaulter.py
@@ -79,6 +79,8 @@ class ReplaceEllipsesUsingRuntime(libcst.CSTTransformer):
                 return self.sig.parameters[param_name[2:]]
             except KeyError:
                 pass
+        elif node not in self.stub_params.posonly_params:
+            return None
 
         all_runtime_parameters = self.sig.parameters.values()
         variadic_parameter_kinds = {

--- a/stubdefaulter.py
+++ b/stubdefaulter.py
@@ -133,7 +133,10 @@ class ReplaceEllipsesUsingRuntime(libcst.CSTTransformer):
         if len(all_stub_params) != len(all_runtime_parameters):
             return None
 
-        return all_runtime_parameters[all_stub_params.index(node)]
+        runtime_param = all_runtime_parameters[all_stub_params.index(node)]
+        if runtime_param.kind is inspect.Parameter.POSITIONAL_ONLY:
+            return runtime_param
+        return None
 
     def infer_value_for_default(
         self, node: libcst.Param

--- a/stubdefaulter.py
+++ b/stubdefaulter.py
@@ -106,6 +106,7 @@ class ReplaceEllipsesUsingRuntime(libcst.CSTTransformer):
         # - There are no variadic parameters (*args or **kwargs) at runtime or in the stub
         # - The parameter is marked as being pos-only in the stub,
         #   either through PEP 570 syntax or through a parameter name starting with `__`
+        # - The parameter is also positional-only at runtime
         all_runtime_parameters = list(self.sig.parameters.values())
         variadic_parameter_kinds = {
             inspect.Parameter.VAR_POSITIONAL,

--- a/test_stubdefaulter.py
+++ b/test_stubdefaulter.py
@@ -75,7 +75,7 @@ def useless_runtime(*args, **kwargs):
     if 'enum_default' in kwargs and kwargs['enum_default'] is not re.ASCII:
         raise ValueError("FOOL")
 
-def incorrect_parameter_names_in_stub(x="foo", y="bar", z="baz"):
+def incorrect_parameter_names_in_stub(x="foo", y="bar", *, z="baz"):
     pass
 """
 INPUT_STUB = """

--- a/test_stubdefaulter.py
+++ b/test_stubdefaulter.py
@@ -75,7 +75,7 @@ def useless_runtime(*args, **kwargs):
     if 'enum_default' in kwargs and kwargs['enum_default'] is not re.ASCII:
         raise ValueError("FOOL")
 
-def incorrect_parameter_name_in_stub(x="foo"):
+def incorrect_parameter_names_in_stub(x="foo", y="bar"):
     pass
 """
 INPUT_STUB = """
@@ -132,7 +132,8 @@ def useless_runtime(
     enum_default: Literal[re.ASCII] = ...,
     **kwargs
 ) -> None: ...
-def incorrect_parameter_name_in_stub(__fooooooo: str = ...) -> None: ...
+# The default is not added for baaaaaaar, since it's not marked as positional-only in the stub
+def incorrect_parameter_names_in_stub(__fooooooo: str = ..., baaaaaaar: str = ...) -> None: ...
 """
 EXPECTED_STUB = """
 import enum
@@ -188,7 +189,8 @@ def useless_runtime(
     enum_default: Literal[re.ASCII] = ...,
     **kwargs
 ) -> None: ...
-def incorrect_parameter_name_in_stub(__fooooooo: str = 'foo') -> None: ...
+# The default is not added for baaaaaaar, since it's not marked as positional-only in the stub
+def incorrect_parameter_names_in_stub(__fooooooo: str = 'foo', baaaaaaar: str = ...) -> None: ...
 """
 PKG_NAME = "pkg"
 

--- a/test_stubdefaulter.py
+++ b/test_stubdefaulter.py
@@ -75,7 +75,7 @@ def useless_runtime(*args, **kwargs):
     if 'enum_default' in kwargs and kwargs['enum_default'] is not re.ASCII:
         raise ValueError("FOOL")
 
-def incorrect_parameter_names_in_stub(x="foo", y="bar"):
+def incorrect_parameter_names_in_stub(x="foo", y="bar", z="baz"):
     pass
 """
 INPUT_STUB = """
@@ -132,8 +132,8 @@ def useless_runtime(
     enum_default: Literal[re.ASCII] = ...,
     **kwargs
 ) -> None: ...
-# The default is not added for baaaaaaar, since it's not marked as positional-only in the stub
-def incorrect_parameter_names_in_stub(__fooooooo: str = ..., baaaaaaar: str = ...) -> None: ...
+# Defaults are not added for baaaaaaar or baaaz, since they're not marked as positional-only in the stub
+def incorrect_parameter_names_in_stub(__fooooooo: str = ..., baaaaaaar: str = ..., *, baaz: str = ...) -> None: ...
 """
 EXPECTED_STUB = """
 import enum
@@ -189,8 +189,8 @@ def useless_runtime(
     enum_default: Literal[re.ASCII] = ...,
     **kwargs
 ) -> None: ...
-# The default is not added for baaaaaaar, since it's not marked as positional-only in the stub
-def incorrect_parameter_names_in_stub(__fooooooo: str = 'foo', baaaaaaar: str = ...) -> None: ...
+# Defaults are not added for baaaaaaar or baaaz, since they're not marked as positional-only in the stub
+def incorrect_parameter_names_in_stub(__fooooooo: str = 'foo', baaaaaaar: str = ..., *, baaz: str = ...) -> None: ...
 """
 PKG_NAME = "pkg"
 

--- a/test_stubdefaulter.py
+++ b/test_stubdefaulter.py
@@ -74,6 +74,9 @@ def useless_runtime(*args, **kwargs):
             )
     if 'enum_default' in kwargs and kwargs['enum_default'] is not re.ASCII:
         raise ValueError("FOOL")
+
+def incorrect_parameter_name_in_stub(x="foo"):
+    pass
 """
 INPUT_STUB = """
 import enum
@@ -129,6 +132,7 @@ def useless_runtime(
     enum_default: Literal[re.ASCII] = ...,
     **kwargs
 ) -> None: ...
+def incorrect_parameter_name_in_stub(__fooooooo: str = ...) -> None: ...
 """
 EXPECTED_STUB = """
 import enum
@@ -184,6 +188,7 @@ def useless_runtime(
     enum_default: Literal[re.ASCII] = ...,
     **kwargs
 ) -> None: ...
+def incorrect_parameter_name_in_stub(__fooooooo: str = 'foo') -> None: ...
 """
 PKG_NAME = "pkg"
 


### PR DESCRIPTION
If the number of parameters in the stub matches the number of parameters at runtime, and there are no variadic parameters at runtime, it should be safe to add defaults to the stub *even if* the stub has an incorrect name for the parameter