### PR TITLE
Blacklist a few functions with strange signatures at runtime on py37

### DIFF
--- a/stdlib-blacklist.txt
+++ b/stdlib-blacklist.txt
@@ -36,6 +36,12 @@ types.CodeType.replace
 # https://github.com/python/typeshed/pull/9625
 typing.Sequence.index
 
+# The runtime gives `None` as default values on Python 3.7 for these functions, but not on Python 3.8+
+# Passing `None` in will result in an exception being raised
+cmath.log
+os.utime
+pyexpat.XMLParserType.ExternalEntityParserCreate
+
 # TODO: fix these in typeshed: https://github.com/python/typeshed/issues/9652
 asyncio.base_events.BaseEventLoop.create_connection
 asyncio.base_events.BaseEventLoop.create_server


### PR DESCRIPTION
Stubdefaulter always wants to add defaults to these signatures when I run it on the stdlib stubs using Python 3.7, but the defaults it wants to add look wrong. The `cmath` one is definitely wrong:

```pycon
Python 3.7.16 (default, Jan 17 2023, 16:06:28) [MSC v.1916 64 bit (AMD64)] :: Anaconda, Inc. on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import cmath
>>> help(cmath.log)
Help on built-in function log in module cmath:

log(x, y_obj=None, /)
    The logarithm of z to the given base.

    If the base not specified, returns the natural logarithm (base e) of z.

>>> cmath.log(5, None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: must be real number, not NoneType
```

I haven't verified the other two in the same way, but they don't look correct either.