### PR TITLE
Remove `distutils.dist.Distribution.announce` from the blacklist

### DIFF
--- a/stubdefaulter/stdlib-blacklist.txt
+++ b/stubdefaulter/stdlib-blacklist.txt
@@ -42,10 +42,6 @@ cmath.log
 os.utime
 pyexpat.XMLParserType.ExternalEntityParserCreate
 
-# Adding the default to this method causes stubtest to fail for typeshed's setuptools stubs
-# See https://github.com/python/typeshed/pull/9800
-distutils.dist.Distribution.announce
-
 # TODO: fix these in typeshed: https://github.com/python/typeshed/issues/9652
 asyncio.base_events.BaseEventLoop.create_connection
 asyncio.base_events.BaseEventLoop.create_server


### PR DESCRIPTION
This is no longer necessary following https://github.com/python/typeshed/pull/9795: stubtest now passes for typeshed's `setuptools` stubs even if the correct default parameter is added to the stdlib stub for `distutils.dist.Distribution.announce`