### PR TITLE
Add container defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,9 @@ dev = [
 
 [tool.hatch.build]
 packages = ["stubdefaulter"]
+
+[tool.isort]
+profile = "black"
+line_length = 88
+combine_as_imports = true
+skip_gitignore = true

--- a/stubdefaulter/__init__.py
+++ b/stubdefaulter/__init__.py
@@ -21,7 +21,7 @@ import typing
 from dataclasses import dataclass, field
 from itertools import chain
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Sequence, Tuple, Union
+from typing import Any, Dict, Iterator, List, Sequence, Tuple, Union, cast
 
 import libcst
 import tomli
@@ -54,6 +54,31 @@ def infer_value_of_node(node: libcst.BaseExpression) -> object:
             return -operand
         else:
             return NotImplemented
+    elif isinstance(node, (libcst.List, libcst.Tuple, libcst.Set)):
+        ret = [infer_value_of_node(element.value) for element in node.elements]
+        if all(member is not NotImplemented for member in ret):
+            if isinstance(node, libcst.List):
+                return ret
+            elif isinstance(node, libcst.Tuple):
+                return tuple(ret)
+            else:
+                return set(ret)
+        else:
+            return NotImplemented
+    elif isinstance(node, libcst.Dict):
+        dict_ret = {}
+        for element in node.elements:
+            if isinstance(element, libcst.DictElement):
+                key, value = infer_value_of_node(element.key), infer_value_of_node(
+                    element.value
+                )
+                if key is NotImplemented or value is NotImplemented:
+                    return NotImplemented
+                else:
+                    dict_ret[key] = value
+            else:
+                return NotImplemented
+        return dict_ret
     else:
         return NotImplemented
 
@@ -147,39 +172,85 @@ class ReplaceEllipsesUsingRuntime(libcst.CSTTransformer):
             return None
         if param.default is inspect.Parameter.empty:
             return None
-        if type(param.default) is bool or param.default is None:
-            return libcst.Name(value=str(param.default))
-        elif type(param.default) in {str, bytes}:
-            return libcst.SimpleString(value=repr(param.default))
-        elif type(param.default) is int:
+        return self._infer_value_for_default(node, param.default)
+
+    def _infer_value_for_default(
+        self, node: libcst.Param | None, runtime_default: Any
+    ) -> libcst.BaseExpression | None:
+        if isinstance(runtime_default, (bool, type(None))):
+            return libcst.Name(value=str(runtime_default))
+        elif type(runtime_default) in {str, bytes}:
+            return libcst.SimpleString(value=repr(runtime_default))
+        elif type(runtime_default) is int:
             if (
-                node.annotation
+                node is not None
+                and node.annotation
                 and isinstance(node.annotation.annotation, libcst.Name)
                 and node.annotation.annotation.value == "bool"
             ):
                 # Skip cases where the type is annotated as bool but the default is an int.
                 return None
-            if param.default >= 0:
-                return libcst.Integer(value=str(param.default))
+            if runtime_default >= 0:
+                return libcst.Integer(value=str(runtime_default))
             else:
                 return libcst.UnaryOperation(
                     operator=libcst.Minus(),
-                    expression=libcst.Integer(value=str(-param.default)),
+                    expression=libcst.Integer(value=str(-runtime_default)),
                 )
-        elif type(param.default) is float:
-            if not math.isfinite(param.default):
+        elif type(runtime_default) is float:
+            if not math.isfinite(runtime_default):
                 # Edge cases that it's probably not worth handling
                 return None
             # `-0.0 == +0.0`, but we want to keep the sign,
             # so use math.copysign() rather than a comparison with 0
             # to determine whether or not it's a negative float
-            if math.copysign(1, param.default) < 0:
+            if math.copysign(1, runtime_default) < 0:
                 return libcst.UnaryOperation(
                     operator=libcst.Minus(),
-                    expression=libcst.Float(value=str(-param.default)),
+                    expression=libcst.Float(value=str(-runtime_default)),
                 )
             else:
-                return libcst.Float(value=str(param.default))
+                return libcst.Float(value=str(runtime_default))
+        elif type(runtime_default) in {tuple, list} or (
+            type(runtime_default) is set and len(runtime_default) > 0
+        ):
+            members = [
+                self._infer_value_for_default(None, member)
+                for member in runtime_default
+            ]
+            if any(member is None for member in members):
+                return None
+            libcst_cls: type[libcst.Tuple | libcst.List | libcst.Set]
+            if isinstance(runtime_default, tuple):
+                libcst_cls = libcst.Tuple
+            elif isinstance(runtime_default, list):
+                libcst_cls = libcst.List
+            else:
+                libcst_cls = libcst.Set
+            return libcst_cls(
+                elements=[
+                    libcst.Element(cast(libcst.BaseExpression, member))
+                    for member in members
+                ]
+            )
+        elif type(runtime_default) is dict:
+            mapping = {
+                self._infer_value_for_default(None, key): self._infer_value_for_default(
+                    None, value
+                )
+                for key, value in runtime_default.items()
+            }
+            if any(key is None or value is None for key, value in mapping.items()):
+                return None
+            return libcst.Dict(
+                elements=[
+                    libcst.DictElement(
+                        key=cast(libcst.BaseExpression, key),
+                        value=cast(libcst.BaseExpression, value),
+                    )
+                    for key, value in mapping.items()
+                ]
+            )
         return None
 
     def leave_Param(

--- a/stubdefaulter/__init__.py
+++ b/stubdefaulter/__init__.py
@@ -215,7 +215,7 @@ class ReplaceEllipsesUsingRuntime(libcst.CSTTransformer):
                 self._infer_value_for_default(None, member)
                 for member in runtime_default
             ]
-            if any(member is None for member in members):
+            if None in members:
                 return None
             # pyanalyze doesn't like us using lowercase type[] here on <3.9
             libcst_cls: Type[libcst.Tuple | libcst.List]
@@ -235,7 +235,7 @@ class ReplaceEllipsesUsingRuntime(libcst.CSTTransformer):
                 self._infer_value_for_default(None, member)
                 for member in sorted(runtime_default, key=repr)
             ]
-            if any(member is None for member in members):
+            if None in members:
                 return None
             return libcst.Set(
                 elements=[
@@ -250,7 +250,7 @@ class ReplaceEllipsesUsingRuntime(libcst.CSTTransformer):
                 )
                 for key, value in runtime_default.items()
             }
-            if any(key is None or value is None for key, value in mapping.items()):
+            if None in mapping or None in mapping.values():
                 return None
             return libcst.Dict(
                 elements=[

--- a/stubdefaulter/__init__.py
+++ b/stubdefaulter/__init__.py
@@ -233,6 +233,8 @@ class ReplaceEllipsesUsingRuntime(libcst.CSTTransformer):
                 return None
             members = [
                 self._infer_value_for_default(None, member)
+                # Sort by the repr so that the output of stubdefaulter is deterministic,
+                # since the ordering of a set at runtime isn't deterministic
                 for member in sorted(runtime_default, key=repr)
             ]
             if None in members:

--- a/stubdefaulter/__init__.py
+++ b/stubdefaulter/__init__.py
@@ -182,7 +182,7 @@ class ReplaceEllipsesUsingRuntime(libcst.CSTTransformer):
             return libcst.SimpleString(value=repr(runtime_default))
         elif type(runtime_default) is int:
             if (
-                node is not None
+                node
                 and node.annotation
                 and isinstance(node.annotation.annotation, libcst.Name)
                 and node.annotation.annotation.value == "bool"

--- a/stubdefaulter/__init__.py
+++ b/stubdefaulter/__init__.py
@@ -56,15 +56,14 @@ def infer_value_of_node(node: libcst.BaseExpression) -> object:
             return NotImplemented
     elif isinstance(node, (libcst.List, libcst.Tuple, libcst.Set)):
         ret = [infer_value_of_node(element.value) for element in node.elements]
-        if all(member is not NotImplemented for member in ret):
-            if isinstance(node, libcst.List):
-                return ret
-            elif isinstance(node, libcst.Tuple):
-                return tuple(ret)
-            else:
-                return set(ret)
-        else:
+        if NotImplemented in ret:
             return NotImplemented
+        elif isinstance(node, libcst.List):
+            return ret
+        elif isinstance(node, libcst.Tuple):
+            return tuple(ret)
+        else:
+            return set(ret)
     elif isinstance(node, libcst.Dict):
         dict_ret = {}
         for element in node.elements:

--- a/stubdefaulter/__init__.py
+++ b/stubdefaulter/__init__.py
@@ -21,7 +21,7 @@ import typing
 from dataclasses import dataclass, field
 from itertools import chain
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Sequence, Tuple, Union, cast
+from typing import Any, Dict, Iterator, List, Sequence, Tuple, Type, Union, cast
 
 import libcst
 import tomli
@@ -220,7 +220,8 @@ class ReplaceEllipsesUsingRuntime(libcst.CSTTransformer):
             ]
             if any(member is None for member in members):
                 return None
-            libcst_cls: type[libcst.Tuple | libcst.List | libcst.Set]
+            # pyanalyze doesn't like us using lowercase type[] here on <3.9
+            libcst_cls: Type[libcst.Tuple | libcst.List | libcst.Set]
             if isinstance(runtime_default, tuple):
                 libcst_cls = libcst.Tuple
             elif isinstance(runtime_default, list):

--- a/stubdefaulter/__init__.py
+++ b/stubdefaulter/__init__.py
@@ -230,6 +230,8 @@ class ReplaceEllipsesUsingRuntime(libcst.CSTTransformer):
             )
         elif type(runtime_default) is set:
             if not runtime_default:
+                # The empty set is a "call expression", not a literal;
+                # we only want to add defaults where they can be expressed as literals
                 return None
             members = [
                 self._infer_value_for_default(None, member)
@@ -246,10 +248,9 @@ class ReplaceEllipsesUsingRuntime(libcst.CSTTransformer):
                 ]
             )
         elif type(runtime_default) is dict:
+            infer_default = self._infer_value_for_default
             mapping = {
-                self._infer_value_for_default(None, key): self._infer_value_for_default(
-                    None, value
-                )
+                infer_default(None, key): infer_default(None, value)
                 for key, value in runtime_default.items()
             }
             if None in mapping or None in mapping.values():

--- a/test_stubdefaulter.py
+++ b/test_stubdefaulter.py
@@ -33,8 +33,7 @@ def containers(
     c={},
     d=(1, "foo", b"bar", True, None, 1.23),
     e=[1, "foo", b"bar", True, None, 1.23],
-    # Can't test with a set with >1 element as the order is non-deterministic!
-    f={1},
+    f={1, "foo", b"bar", False, None, 1.23},
     g={-1: 1, "foo": "foo", b"bar": "bar", True: False, None: None, 1.23: 1.234},
 ):
     pass
@@ -121,7 +120,7 @@ def containers(
     c: dict[str, int] = ...,
     d: tuple[object, ...] = ...,
     e: list[object] = ...,
-    f: set[int] = ...,
+    f: set[object] = ...,
     g: dict[object, object] = ...,
 ) -> None: ...
 def bad_container(x: set[int] = ...) -> None: ...
@@ -188,7 +187,7 @@ def containers(
     c: dict[str, int] = {},
     d: tuple[object, ...] = (1, 'foo', b'bar', True, None, 1.23),
     e: list[object] = [1, 'foo', b'bar', True, None, 1.23],
-    f: set[int] = {1},
+    f: set[object] = {'foo', 1, 1.23, False, None, b'bar'},
     g: dict[object, object] = {-1: 1, 'foo': 'foo', b'bar': 'bar', True: False, None: None, 1.23: 1.234},
 ) -> None: ...
 def bad_container(x: set[int] = ...) -> None: ...
@@ -288,10 +287,10 @@ def test_stubdefaulter() -> None:
         [],
         (),
         {},
-        (1, "foo", b"bar", True, None, 1.23),
-        [1, "foo", b"bar", True, None, 1.23],
+        (1, "foo", b"bar", True, None, 1.23, ["foo", ("bar", 1)]),
+        [1, "foo", b"bar", True, None, 1.23, (1, {b"bar": False})],
         {1},
-        {-1: 1, "foo": "foo", b"bar": "bar", True: False, None: None, 1.23: 1.234},
+        {-1: 1, "foo": "foo", (b"bar", b"baz"): "bar", False: [1, 2, {2, 3, 4}]},
     ],
 )
 def test_infer_value_of_node_known_types(obj: object) -> None:

--- a/test_stubdefaulter.py
+++ b/test_stubdefaulter.py
@@ -27,6 +27,19 @@ def float_edge_cases(one=float("nan"), two=float("inf"), three=float("-inf")):
     pass
 def bytes_func(one=b"foo"):
     pass
+def containers(
+    a=(),
+    b=[],
+    c={},
+    d=(1, "foo", b"bar", True, None, 1.23),
+    e=[1, "foo", b"bar", True, None, 1.23],
+    # Can't test with a set with >1 element as the order is non-deterministic!
+    f={1},
+    g={-1: 1, "foo": "foo", b"bar": "bar", True: False, None: None, 1.23: 1.234},
+):
+    pass
+def bad_container(x=set()):
+    pass
 
 class Capybara:
     def __init__(self, x=0, y="y", z=True, a=None):
@@ -102,6 +115,16 @@ def wrong_default(wrong: int = 1) -> None: ...
 def floats(a: float = ..., b: float = ..., c: float = ..., d: float = ...) -> None: ...
 def float_edge_cases(one: float = ..., two: float = ..., three: float = ...) -> None: ...
 def bytes_func(one: bytes = ...) -> None: ...
+def containers(
+    a: tuple[str, ...] = ...,
+    b: list[str] = ...,
+    c: dict[str, int] = ...,
+    d: tuple[object, ...] = ...,
+    e: list[object] = ...,
+    f: set[int] = ...,
+    g: dict[object, object] = ...,
+) -> None: ...
+def bad_container(x: set[int] = ...) -> None: ...
 
 class Capybara:
     def __init__(self, x: int = ..., y: str = ..., z: bool = ..., a: Any = ...) -> None: ...
@@ -159,6 +182,16 @@ def wrong_default(wrong: int = 1) -> None: ...
 def floats(a: float = 1.23456, b: float = 0.0, c: float = -9.87654, d: float = -0.0) -> None: ...
 def float_edge_cases(one: float = ..., two: float = ..., three: float = ...) -> None: ...
 def bytes_func(one: bytes = b'foo') -> None: ...
+def containers(
+    a: tuple[str, ...] = (),
+    b: list[str] = [],
+    c: dict[str, int] = {},
+    d: tuple[object, ...] = (1, 'foo', b'bar', True, None, 1.23),
+    e: list[object] = [1, 'foo', b'bar', True, None, 1.23],
+    f: set[int] = {1},
+    g: dict[object, object] = {-1: 1, 'foo': 'foo', b'bar': 'bar', True: False, None: None, 1.23: 1.234},
+) -> None: ...
+def bad_container(x: set[int] = ...) -> None: ...
 
 class Capybara:
     def __init__(self, x: int = 0, y: str = 'y', z: bool = True, a: Any = None) -> None: ...
@@ -237,7 +270,29 @@ def test_stubdefaulter() -> None:
 
 
 @pytest.mark.parametrize(
-    "obj", [-1, 0, 1, 2, -1.1, -0.0, 0.0, 1.1, True, False, None, "foo", b"bar"]
+    "obj",
+    [
+        -1,
+        0,
+        1,
+        2,
+        -1.1,
+        -0.0,
+        0.0,
+        1.1,
+        True,
+        False,
+        None,
+        "foo",
+        b"bar",
+        [],
+        (),
+        {},
+        (1, "foo", b"bar", True, None, 1.23),
+        [1, "foo", b"bar", True, None, 1.23],
+        {1},
+        {-1: 1, "foo": "foo", b"bar": "bar", True: False, None: None, 1.23: 1.234},
+    ],
 )
 def test_infer_value_of_node_known_types(obj: object) -> None:
     node = libcst.parse_expression(repr(obj))
@@ -247,7 +302,7 @@ def test_infer_value_of_node_known_types(obj: object) -> None:
     assert repr(inferred_value) == repr(obj)
 
 
-@pytest.mark.parametrize("obj", [3j, [], (), {}, bytearray()])
+@pytest.mark.parametrize("obj", [3j, bytearray(), set()])
 def test_infer_value_of_node_unknown_types(obj: object) -> None:
     node = libcst.parse_expression(repr(obj))
     inferred_value = stubdefaulter.infer_value_of_node(node)


### PR DESCRIPTION
This required a little bit of refactoring -- I had to introduce a new `ReplaceEllipsesUsingRuntime._infer_value_for_default` method, so that I had a method I could call recursively.

I've checked locally, and the changes `stubdefaulter` would make to typeshed's stdlib with this PR applied pass both mypy and flake8-pyi.