### PR TITLE
Add linting error codes and configurable fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # stubdefaulter
 
-A tool for automatically adding default values to Python type stubs.
+A tool for linting and autofixing Python type stubs.
+
+Currently, it supports the following checks:
+- `missing-default`: parameters missing a default value (has autofix)
+- `wrong-default`: the default value of a parameter differs from the runtime
+- `missing-slots`: for classes that define `__slots__` at runtime but not in the stub
 
 ## Background
 
@@ -12,6 +17,20 @@ files are also useful for IDEs, which do want to show defaults. Therefore, the
 typeshed project has [decided](https://github.com/python/typeshed/issues/8988) to
 allow defaults for stubs. This tool provides a way to auto-add defaults for stubs.
 
+More generally, this tool provides the following useful combination of features
+for linting stubs:
+- Runtime-aware: it can compare stubs against the corresponding runtime object
+- Capable of autofixes
+
+Therefore, I am now expanding it with other useful checks. Comparable tools include:
+- `stubtest`, a tool distributed with mypy that compares stubs against the runtime
+  and produces errors, but not autofixes
+- `stubgen`, another tool bundled with mypy that can generate stubs from scratch
+- `flake8-pyi`, a linter for stubs
+- `ruff`, a general Python linter; it incorporates the rules from flake8-pyi and adds
+  some autofixes
+- `docstring-adder`, a tool that adds docstrings to stubs
+
 ## Usage
 
 Warning: The tool will import and/or install various packages. Make sure you
@@ -20,11 +39,7 @@ virtual environment.
 
 - Install the package by running `pip install stubdefaulter`
 - Invoke it as `python -m stubdefaulter`
-- The tool is now a linter with error codes:
-  - `missing-default` for parameters that are missing a default value
-  - `wrong-default` for parameters whose stub default differs from runtime
-  - `missing-slots` for classes that define `__slots__` at runtime but not in the stub
-- Error codes can be disabled on the command line with `--disable CODE`
+- By default, all checks are enabled. Error codes can be disabled on the command line with `--disable CODE`
 - Use `--fix` to apply autofixes for the selected error codes
 - Example invocations:
   - `python -m stubdefaulter --fix --stdlib-path path/to/typeshed/stdlib`

--- a/README.md
+++ b/README.md
@@ -20,8 +20,14 @@ virtual environment.
 
 - Install the package by running `pip install stubdefaulter`
 - Invoke it as `python -m stubdefaulter`
+- The tool is now a linter with error codes:
+  - `missing-default` for parameters that are missing a default value
+  - `wrong-default` for parameters whose stub default differs from runtime
+  - `missing-slots` for classes that define `__slots__` at runtime but not in the stub
+- Error codes can be disabled on the command line with `--disable CODE`
+- Use `--fix` to apply autofixes for the selected error codes
 - Example invocations:
-  - `python -m stubdefaulter --stdlib-path path/to/typeshed/stdlib`
+  - `python -m stubdefaulter --fix --stdlib-path path/to/typeshed/stdlib`
     - Add defaults to the stdlib stubs in typeshed
   - `python -m stubdefaulter --packages path/to/typeshed/stubs/requests path/to/typeshed/stubs/babel`
     - Add defaults to the `requests` and `babel` packages in typeshed

--- a/stubdefaulter/__init__.py
+++ b/stubdefaulter/__init__.py
@@ -37,6 +37,18 @@ from termcolor import colored
 # for tools that try to parse or display Python source code
 DEFAULT_LENGTH_LIMIT = 500
 
+# Error codes
+MISSING_DEFAULT = "missing-default"
+WRONG_DEFAULT = "wrong-default"
+MISSING_SLOTS = "missing-slots"
+ALL_ERROR_CODES = {MISSING_DEFAULT, WRONG_DEFAULT, MISSING_SLOTS}
+
+
+@dataclass
+class LintError:
+    code: str
+    message: str
+
 
 def default_is_too_long(default: libcst.BaseExpression) -> bool:
     default_as_module = libcst.Module(
@@ -130,8 +142,10 @@ class ReplaceEllipsesUsingRuntime(libcst.CSTTransformer):
     sig: inspect.Signature
     stub_params: libcst.Parameters
     add_complex_defaults: bool = False
+    apply_fixes: bool = False
+    enabled_errors: frozenset[str] = frozenset()
     num_added: int = 0
-    errors: list[tuple[str, object, object]] = field(default_factory=list)
+    errors: list[LintError] = field(default_factory=list)
 
     def get_matching_runtime_parameter(
         self, node: libcst.Param
@@ -322,9 +336,20 @@ class ReplaceEllipsesUsingRuntime(libcst.CSTTransformer):
         inferred_default = self.infer_value_for_default(original_node)
         if inferred_default is None:
             return updated_node
+        param_name = original_node.name.value
         if isinstance(original_node.default, libcst.Ellipsis):
-            self.num_added += 1
-            return updated_node.with_changes(default=inferred_default)
+            if MISSING_DEFAULT in self.enabled_errors:
+                runtime_value = infer_value_of_node(inferred_default)
+                self.errors.append(
+                    LintError(
+                        MISSING_DEFAULT,
+                        f"parameter {param_name} missing default {runtime_value!r}",
+                    )
+                )
+                if self.apply_fixes:
+                    self.num_added += 1
+                    return updated_node.with_changes(default=inferred_default)
+            return updated_node
         else:
             existing_value = infer_value_of_node(original_node.default)
             if existing_value is NotImplemented:
@@ -333,9 +358,16 @@ class ReplaceEllipsesUsingRuntime(libcst.CSTTransformer):
             if existing_value != inferred_value or type(inferred_value) is not type(
                 existing_value
             ):
-                self.errors.append(
-                    (original_node.name.value, existing_value, inferred_value)
-                )
+                if WRONG_DEFAULT in self.enabled_errors:
+                    self.errors.append(
+                        LintError(
+                            WRONG_DEFAULT,
+                            f"parameter {param_name}: stub default {existing_value!r} != runtime default {inferred_value!r}",
+                        )
+                    )
+                    if self.apply_fixes:
+                        self.num_added += 1
+                        return updated_node.with_changes(default=inferred_default)
             return updated_node
 
 
@@ -361,7 +393,9 @@ def replace_defaults_in_func(
     runtime_func: Any,
     *,
     add_complex_defaults: bool = False,
-) -> tuple[int, list[str], dict[int, list[str]]]:
+    enabled_errors: frozenset[str] = frozenset(),
+    apply_fixes: bool = False,
+) -> tuple[int, list[LintError], dict[int, list[str]]]:
     try:
         sig = inspect.signature(runtime_func)
     except Exception:
@@ -374,19 +408,23 @@ def replace_defaults_in_func(
     )
     assert isinstance(cst, libcst.FunctionDef)
     visitor = ReplaceEllipsesUsingRuntime(
-        sig, cst.params, add_complex_defaults=add_complex_defaults
+        sig,
+        cst.params,
+        add_complex_defaults=add_complex_defaults,
+        enabled_errors=enabled_errors,
+        apply_fixes=apply_fixes,
     )
     modified = cst.visit(visitor)
     assert isinstance(modified, libcst.FunctionDef)
-    new_code = textwrap.indent(libcst.Module(body=[modified]).code, " " * indentation)
-    output_dict = {node.lineno - 1: new_code.splitlines()}
-    for i in range(node.lineno, end_lineno):
-        output_dict[i] = []
-    errors = [
-        f"parameter {param_name}: stub default {stub_default!r} != runtime default {runtime_default!r}"
-        for param_name, stub_default, runtime_default in visitor.errors
-    ]
-    return visitor.num_added, errors, output_dict
+    output_dict: dict[int, list[str]] = {}
+    if apply_fixes and visitor.num_added:
+        new_code = textwrap.indent(
+            libcst.Module(body=[modified]).code, " " * indentation
+        )
+        output_dict = {node.lineno - 1: new_code.splitlines()}
+        for i in range(node.lineno, end_lineno):
+            output_dict[i] = []
+    return visitor.num_added, visitor.errors, output_dict
 
 
 def is_ellipsis_stmt(node: ast.stmt) -> bool:
@@ -410,20 +448,30 @@ def add_slots_to_class(
     node: ast.ClassDef,
     runtime_cls: type,
     replacement_lines: dict[int, list[str]],
-) -> int:
+    *,
+    enabled_errors: frozenset[str] = frozenset(),
+    apply_fixes: bool = False,
+    qualname: str,
+) -> tuple[int, list[LintError]]:
     runtime_slots = runtime_cls.__dict__.get("__slots__")
     if runtime_slots is None:
-        return 0
+        return 0, []
     if isinstance(getattr(runtime_cls, "_fields", None), tuple):
         # Probably a namedtuple, which always have empty __slots__. Not interesting.
-        return 0
+        return 0, []
     for stmt in node.body:
         if isinstance(stmt, ast.Assign):
             if any(
                 isinstance(target, ast.Name) and target.id == "__slots__"
                 for target in stmt.targets
             ):
-                return 0
+                return 0, []
+
+    errors: list[LintError] = []
+    if MISSING_SLOTS in enabled_errors:
+        errors.append(LintError(MISSING_SLOTS, f"{qualname} missing __slots__"))
+        if not apply_fixes:
+            return 0, errors
 
     indentation = (
         len(stub_lines[node.lineno - 1]) - len(stub_lines[node.lineno - 1].lstrip()) + 4
@@ -435,7 +483,7 @@ def add_slots_to_class(
         class_line = stub_lines[line_index]
         header = class_line.split(":")[0] + ":"
         replacement_lines[line_index] = [header, new_line]
-        return 1
+        return 1, errors
 
     if node.body and is_docstring_stmt(node.body[0]):
         doc = node.body[0]
@@ -453,7 +501,7 @@ def add_slots_to_class(
             replacement_lines[line_index] = [new_line, stub_lines[line_index]]
         else:
             replacement_lines[line_index] = [new_line]
-    return 1
+    return 1, errors
 
 
 def gather_classes(
@@ -462,7 +510,7 @@ def gather_classes(
     fullname: str,
     runtime_parent: type | types.ModuleType,
     blacklisted_objects: frozenset[str],
-) -> Iterator[tuple[ast.ClassDef, type[object]]]:
+) -> Iterator[tuple[ast.ClassDef, type[object], str]]:
     if fullname in blacklisted_objects:
         log(f"Skipping {fullname}: blacklisted object")
         return
@@ -479,7 +527,7 @@ def gather_classes(
         log("Could not find", fullname, "at runtime")
         return
     if isinstance(runtime, type):
-        yield node.ast, runtime
+        yield node.ast, runtime, fullname
     if node.child_nodes is not None:
         for child_name, child_node in node.child_nodes.items():
             if child_name.startswith("__") and not child_name.endswith("__"):
@@ -500,11 +548,11 @@ def gather_classes(
 
 def gather_funcs(
     node: typeshed_client.NameInfo,
-    name: str,
+   name: str,
     fullname: str,
     runtime_parent: type | types.ModuleType,
     blacklisted_objects: frozenset[str],
-) -> Iterator[tuple[ast.FunctionDef | ast.AsyncFunctionDef, Any]]:
+) -> Iterator[tuple[ast.FunctionDef | ast.AsyncFunctionDef, Any, str]]:
     if fullname in blacklisted_objects:
         log(f"Skipping {fullname}: blacklisted object")
         return
@@ -549,9 +597,9 @@ def gather_funcs(
     elif isinstance(node.ast, typeshed_client.OverloadedName):
         for definition in node.ast.definitions:
             if isinstance(definition, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                yield definition, runtime
+                yield definition, runtime, fullname
     elif isinstance(node.ast, (ast.FunctionDef, ast.AsyncFunctionDef)):
-        yield node.ast, runtime
+        yield node.ast, runtime, fullname
 
 
 def add_defaults_to_stub_using_runtime(
@@ -561,7 +609,9 @@ def add_defaults_to_stub_using_runtime(
     *,
     slots: bool = False,
     add_complex_defaults: bool = False,
-) -> tuple[list[str], int, int]:
+    enabled_errors: frozenset[str] = frozenset(),
+    apply_fixes: bool = False,
+) -> tuple[list[LintError], int, int]:
     path = typeshed_client.get_stub_file(module_name, search_context=context)
     if path is None:
         raise ValueError(f"Could not find stub for {module_name}")
@@ -583,7 +633,7 @@ def add_defaults_to_stub_using_runtime(
     replacement_lines: dict[int, list[str]] = {}
     num_defaults_added = 0
     num_slots_added = 0
-    errors = []
+    errors: list[LintError] = []
     for name, info in stub_names.items():
         funcs = gather_funcs(
             node=info,
@@ -593,18 +643,21 @@ def add_defaults_to_stub_using_runtime(
             blacklisted_objects=blacklisted_objects,
         )
 
-        for func, runtime_func in funcs:
+        for func, runtime_func, qualname in funcs:
             num_added, new_errors, new_lines = replace_defaults_in_func(
                 stub_lines,
                 func,
                 runtime_func,
                 add_complex_defaults=add_complex_defaults,
+                enabled_errors=enabled_errors,
+                apply_fixes=apply_fixes,
             )
             for error in new_errors:
-                message = f"{module_name}.{name}: {error}"
-                errors.append(message)
-                print(colored(message, "red"))
-            replacement_lines.update(new_lines)
+                message = f"{qualname}: {error.message}"
+                errors.append(LintError(error.code, message))
+                print(colored(f"{qualname}: [{error.code}] {error.message}", "red"))
+            if new_lines:
+                replacement_lines.update(new_lines)
             num_defaults_added += num_added
     if slots:
         for name, info in stub_names.items():
@@ -615,23 +668,35 @@ def add_defaults_to_stub_using_runtime(
                 runtime_parent=runtime_module,
                 blacklisted_objects=blacklisted_objects,
             )
-            for class_node, runtime_cls in classes:
-                num_slots_added += add_slots_to_class(
-                    stub_lines, class_node, runtime_cls, replacement_lines
+            for class_node, runtime_cls, qualname in classes:
+                slots_added, slot_errors = add_slots_to_class(
+                    stub_lines,
+                    class_node,
+                    runtime_cls,
+                    replacement_lines,
+                    enabled_errors=enabled_errors,
+                    apply_fixes=apply_fixes,
+                    qualname=qualname,
                 )
-    with path.open("w", encoding="utf-8") as f:
-        for i, line in enumerate(stub_lines):
-            if i in replacement_lines:
-                for new_line in replacement_lines[i]:
-                    f.write(new_line + "\n")
-            else:
-                f.write(line + "\n")
+                errors.extend(slot_errors)
+                num_slots_added += slots_added
+    if apply_fixes and replacement_lines:
+        with path.open("w", encoding="utf-8") as f:
+            for i, line in enumerate(stub_lines):
+                if i in replacement_lines:
+                    for new_line in replacement_lines[i]:
+                        f.write(new_line + "\n")
+                else:
+                    f.write(line + "\n")
     return errors, num_defaults_added, num_slots_added
 
 
 @dataclass
 class ReplaceEllipsesUsingAnnotations(libcst.CSTTransformer):
+    enabled_errors: frozenset[str]
+    apply_fixes: bool
     num_added: int = 0
+    errors: list[LintError] = field(default_factory=list)
 
     @staticmethod
     def node_represents_subscripted_Literal(
@@ -656,13 +721,13 @@ class ReplaceEllipsesUsingAnnotations(libcst.CSTTransformer):
         annotation = original_node.annotation
         if not isinstance(annotation, libcst.Annotation):
             return updated_node
+        new_default: libcst.BaseExpression | None = None
         if (
             isinstance(annotation.annotation, libcst.Name)
             and annotation.annotation.value == "None"
         ):
-            self.num_added += 1
-            return updated_node.with_changes(default=libcst.Name(value="None"))
-        if isinstance(
+            new_default = libcst.Name(value="None")
+        elif isinstance(
             annotation.annotation, libcst.Subscript
         ) and self.node_represents_subscripted_Literal(annotation.annotation):
             subscript = annotation.annotation
@@ -675,24 +740,42 @@ class ReplaceEllipsesUsingAnnotations(libcst.CSTTransformer):
                 ) is not NotImplemented and not default_is_too_long(
                     literal_slice_contents
                 ):
-                    self.num_added += 1
-                    return updated_node.with_changes(default=literal_slice_contents)
+                    new_default = literal_slice_contents
+        if new_default is None:
+            return updated_node
+        if MISSING_DEFAULT in self.enabled_errors:
+            runtime_value = infer_value_of_node(new_default)
+            self.errors.append(
+                LintError(
+                    MISSING_DEFAULT,
+                    f"parameter {original_node.name.value} missing default {runtime_value!r}",
+                )
+            )
+            if self.apply_fixes:
+                self.num_added += 1
+                return updated_node.with_changes(default=new_default)
         return updated_node
 
 
 def add_defaults_to_stub_using_annotations(
-    module_name: str, context: typeshed_client.finder.SearchContext
-) -> int:
+    module_name: str,
+    context: typeshed_client.finder.SearchContext,
+    *,
+    enabled_errors: frozenset[str] = frozenset(),
+    apply_fixes: bool = False,
+) -> tuple[list[LintError], int]:
     path = typeshed_client.get_stub_file(module_name, search_context=context)
     if path is None:
         raise ValueError(f"Could not find stub for {module_name}")
     source = path.read_text(encoding="utf-8")
     cst = libcst.parse_module(source)
-    visitor = ReplaceEllipsesUsingAnnotations()
+    visitor = ReplaceEllipsesUsingAnnotations(
+        enabled_errors=enabled_errors, apply_fixes=apply_fixes
+    )
     modified_cst = cst.visit(visitor)
-    if visitor.num_added > 0:
+    if apply_fixes and visitor.num_added > 0:
         path.write_text(modified_cst.code, encoding="utf-8")
-    return visitor.num_added
+    return visitor.errors, visitor.num_added
 
 
 def add_defaults_to_stub(
@@ -702,20 +785,28 @@ def add_defaults_to_stub(
     *,
     slots: bool = False,
     add_complex_defaults: bool = False,
-) -> tuple[list[str], int, int]:
+    enabled_errors: frozenset[str] = frozenset(),
+    apply_fixes: bool = False,
+) -> tuple[list[LintError], int, int]:
     print(f"Processing {module_name}... ", end="", flush=True)
-    num_added_using_annotations = add_defaults_to_stub_using_annotations(
-        module_name, context
+    ann_errors, num_added_using_annotations = add_defaults_to_stub_using_annotations(
+        module_name,
+        context,
+        enabled_errors=enabled_errors,
+        apply_fixes=apply_fixes,
     )
-    errors, num_added_using_runtime, num_slots_added = (
+    runtime_errors, num_added_using_runtime, num_slots_added = (
         add_defaults_to_stub_using_runtime(
             module_name,
             context,
             blacklisted_objects,
             slots=slots,
             add_complex_defaults=add_complex_defaults,
+            enabled_errors=enabled_errors,
+            apply_fixes=apply_fixes,
         )
     )
+    errors = ann_errors + runtime_errors
     total_num_added = num_added_using_annotations + num_added_using_runtime
     print(f"added {total_num_added} defaults and {num_slots_added} slots")
     return errors, total_num_added, num_slots_added
@@ -837,6 +928,18 @@ def main() -> None:
             "Add complex defaults that are not allowed by typeshed's default linting settings."
         ),
     )
+    parser.add_argument(
+        "--disable",
+        nargs="*",
+        choices=sorted(ALL_ERROR_CODES),
+        default=[],
+        help="Disable specific error codes",
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Apply autofixes to stubs",
+    )
     args = parser.parse_args()
 
     stdlib_path = Path(args.stdlib_path) if args.stdlib_path else None
@@ -857,7 +960,8 @@ def main() -> None:
     context = typeshed_client.finder.get_search_context(
         typeshed=stdlib_path, search_path=package_paths, version=sys.version_info[:2]
     )
-    errors = []
+    enabled_errors = frozenset(ALL_ERROR_CODES - set(args.disable))
+    errors: list[LintError] = []
     num_defaults_added = 0
     num_slots_added = 0
     for module, path in typeshed_client.get_all_stub_files(context):
@@ -875,6 +979,8 @@ def main() -> None:
                     combined_blacklist,
                     slots=args.slots,
                     add_complex_defaults=args.add_complex_defaults,
+                    enabled_errors=enabled_errors,
+                    apply_fixes=args.fix,
                 )
                 errors += these_errors
                 num_defaults_added += num_defaults
@@ -886,6 +992,8 @@ def main() -> None:
                 combined_blacklist,
                 slots=args.slots,
                 add_complex_defaults=args.add_complex_defaults,
+                enabled_errors=enabled_errors,
+                apply_fixes=args.fix,
             )
             errors += these_errors
             num_defaults_added += num_defaults

--- a/stubdefaulter/__init__.py
+++ b/stubdefaulter/__init__.py
@@ -548,7 +548,7 @@ def gather_classes(
 
 def gather_funcs(
     node: typeshed_client.NameInfo,
-   name: str,
+    name: str,
     fullname: str,
     runtime_parent: type | types.ModuleType,
     blacklisted_objects: frozenset[str],

--- a/test_stubdefaulter.py
+++ b/test_stubdefaulter.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import libcst
 import pytest
-import typeshed_client
+import typeshed_client.finder
 
 import stubdefaulter
 
@@ -284,14 +284,16 @@ def test_stubdefaulter() -> None:
         (pkg_path / "__init__.py").write_text(PY_FILE)
         (pkg_path / "py.typed").write_text("typed\n")
 
+        config = stubdefaulter.Config(
+            enabled_errors=stubdefaulter.ALL_ERROR_CODES,
+            apply_fixes=True,
+            add_complex_defaults=True,
+            blacklisted_objects=frozenset(),
+        )
         errors, _, _ = stubdefaulter.add_defaults_to_stub(
             PKG_NAME,
             typeshed_client.finder.get_search_context(search_path=[td]),
-            frozenset(),
-            slots=True,
-            add_complex_defaults=True,
-            enabled_errors=stubdefaulter.ALL_ERROR_CODES,
-            apply_fixes=True,
+            config=config,
         )
         assert stub_path.read_text() == EXPECTED_STUB
         codes = {e.code for e in errors}
@@ -303,11 +305,7 @@ def test_stubdefaulter() -> None:
         errors, _, _ = stubdefaulter.add_defaults_to_stub(
             PKG_NAME,
             typeshed_client.finder.get_search_context(search_path=[td]),
-            frozenset(),
-            slots=True,
-            add_complex_defaults=True,
-            enabled_errors=stubdefaulter.ALL_ERROR_CODES,
-            apply_fixes=True,
+            config=config,
         )
         assert stub_path.read_text() == EXPECTED_STUB
         codes = {e.code for e in errors}


### PR DESCRIPTION
## Summary
- Turn stubdefaulter into a linter with structured error codes
- Allow disabling `missing-default`, `wrong-default`, and `missing-slots`
- Add `--fix` flag to control whether autofixes are applied

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a754a19b4483298cbca7d9518fdf9e